### PR TITLE
feat: checkout to switch all repo to same branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ Usage: gith checkout [OPTIONS] INDEX
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --pull    --no-pull      Pull the latest changes from the remote repository after switching branches. [default: pull]                  │
+│ --dir                    To specify if when you have many repo in the current directory to checkout to same branch                     │
+│ --b                      The branch you want to checkout all repo in directory. It's required if you use --dir                         │
 │ --help                   Show this message and exit.                                                                                   │
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -240,6 +242,12 @@ When you do checkout to a local branch that was not pushed yet to origin, you wi
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 > The motivation behind this command was to speed up the checkout process, ensuring automatic pull and branch handling by indexes.
+
+### Checkout many repo in a directory to same branch
+
+`gith checkout --dir=/path/to/dir -b branch_name`
+
+> Motivation : mainly used in Odoo where many modules are in same directory and these modules have branches' names that represent the Odoo version.
 
 ## gith repo ...
 

--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ Usage: gith checkout [OPTIONS] INDEX
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --pull    --no-pull      Pull the latest changes from the remote repository after switching branches. [default: pull]                  │
-│ --dir                    To specify if when you have many repo in the current directory to checkout to same branch                     │
-│ --b                      The branch you want to checkout all repo in directory. It's required if you use --dir                         │
+│ --dir                    Directory containing multiple git repositories to checkout to the same branch.                                │
+│ --branch  -b             Branch name to checkout in each repository. Required when --dir is used.                                      │
 │ --help                   Show this message and exit.                                                                                   │
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/gith/cli.py
+++ b/gith/cli.py
@@ -1,12 +1,13 @@
 import configparser
 import os
+from pathlib import Path
+from typing import List, Optional
+
 import typer
 from rich.console import Console
-from typing import List
 
 from .helpers import gith
 from .messages import GithMessage, GithMessageLevel
-from pathlib import Path
 
 app = typer.Typer()
 console = Console()
@@ -106,8 +107,8 @@ def branch(
 
 @app.command()
 def checkout(
-    index: int = typer.Argument(
-        ...,
+    index: Optional[int] = typer.Argument(
+        None,
         help="Index of the branch to checkout to. Autocompletion available.",
         autocompletion=branch_name_autocomplete,
     ),
@@ -115,15 +116,36 @@ def checkout(
         True,
         help="Pull the latest changes from the remote repository after switching branches.",
     ),
+    dir: Optional[str] = typer.Option(
+        None,
+        "--dir",
+        help="Directory with multiple repositories to checkout to same branch.",
+    ),
+    branch: Optional[str] = typer.Option(
+        None,
+        "--b",
+        help="Branch name to checkout, used with --dir)",
+    ),
 ):
     """
     A helper command to checkout to a branch by its index.
     """
-    branches = gith.git_branch(verbose=False)
-    branch_to_checkout = branches[index - 1]
-    gith.checkout_to_branch(branch_to_checkout)
-    if pull:
-        gith.git_pull(branch_to_checkout)
+    if dir:
+        if not branch:
+            GithMessage("--b is required when using --dir.", GithMessageLevel.ERROR)
+        gith.checkout_dir(dir, branch)
+    else:
+        if not index:
+            # FIXME: case of branch not found locally but exist in remote
+            # issue at https://github.com/rejamen/gith/issues/12
+            GithMessage(
+                "Provide a branch index, or use --dir with --b", GithMessageLevel.ERROR
+            )
+        branches = gith.git_branch(verbose=False)
+        branch_to_checkout = branches[index - 1]
+        gith.checkout_to_branch(branch_to_checkout)
+        if pull:
+            gith.git_pull(branch_to_checkout)
 
 
 @app.command()

--- a/gith/cli.py
+++ b/gith/cli.py
@@ -116,30 +116,30 @@ def checkout(
         True,
         help="Pull the latest changes from the remote repository after switching branches.",
     ),
-    dir: Optional[str] = typer.Option(
+    directory: Optional[str] = typer.Option(
         None,
         "--dir",
-        help="Directory with multiple repositories to checkout to same branch.",
+        help="Directory containing multiple git repositories to checkout to the same branch.",
     ),
     branch: Optional[str] = typer.Option(
         None,
-        "--b",
-        help="Branch name to checkout, used with --dir)",
+        "--branch",
+        "-b",
+        help="Branch name to checkout, used with --dir.",
     ),
 ):
     """
     A helper command to checkout to a branch by its index.
     """
-    if dir:
+    if directory:
         if not branch:
-            GithMessage("--b is required when using --dir.", GithMessageLevel.ERROR)
-        gith.checkout_dir(dir, branch)
+            GithMessage("--branch is required when using --dir.", GithMessageLevel.ERROR)
+        gith.checkout_dir(directory, branch)
     else:
-        if not index:
-            # FIXME: case of branch not found locally but exist in remote
-            # issue at https://github.com/rejamen/gith/issues/12
+        if index is None:
             GithMessage(
-                "Provide a branch index, or use --dir with --b", GithMessageLevel.ERROR
+                "Provide a branch index, or use --dir with --branch.",
+                GithMessageLevel.ERROR,
             )
         branches = gith.git_branch(verbose=False)
         branch_to_checkout = branches[index - 1]

--- a/gith/helpers.py
+++ b/gith/helpers.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from pathlib import Path
 from typing import Dict, List, Optional
 
 from .console import GithConsole
@@ -375,7 +376,69 @@ class GithHelper:
         else:
             GithMessage(
                 f"Error setting local user email: {result.stderr}",
-                GithMessageLevel.ERROR
+                GithMessageLevel.ERROR,
             )
+
+    def checkout_dir(self, path: str, branch_name: str) -> None:
+        """
+        Checkout all git repo inside a directory to the same branch.
+        When branch not found in repo, skip with warning message.
+
+        Args:
+            path (str): Path to the directory containing the git repos.
+            branch_name (str): The branch to checkout in each repo.
+        """
+        base = Path(path).resolve()
+        subdirs = sorted(p for p in base.iterdir() if (p / ".git").is_dir())
+
+        if not subdirs:
+            GithMessage(f"No git repo found in {base}", GithMessageLevel.ERROR)
+
+        switched, skipped = 0, 0
+
+        for repo_path in subdirs:
+            name = repo_path.name
+
+            # git -C <path> runs git like we are in the repo directory
+            result = subprocess.run(
+                ["git", "-C", repo_path, "branch", "--list", branch_name],
+                capture_output=True,
+                text=True,
+            )
+            branch_exists_locally = branch_name in result.stdout
+
+            # FIXME : case of branch not found locally but exist in remote
+            # issue at https://github.com/rejamen/gith/issues/12
+            if not branch_exists_locally:
+                GithMessage(
+                    f"[yellow]{name}[/yellow]: branch [red]{branch_name}[/red] not found — skipped",
+                    GithMessageLevel.INFO,
+                )
+                skipped += 1
+                continue
+
+            result = subprocess.run(
+                ["git", "-C", repo_path, "checkout", branch_name],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                GithMessage(
+                    f"[yellow]{name}[/yellow]: switched to [green]{branch_name}[/green]",
+                    GithMessageLevel.LOG,
+                )
+                switched += 1
+            else:
+                GithMessage(
+                    f"[yellow]{name}[/yellow]: error — {result.stderr.strip()}",
+                    GithMessageLevel.INFO,
+                )
+                skipped += 1
+
+        GithMessage(
+            f"Done. [green]{switched} switched[/green], [red]{skipped} skipped[/red].",
+            GithMessageLevel.LOG,
+        )
+
 
 gith = GithHelper()

--- a/gith/helpers.py
+++ b/gith/helpers.py
@@ -389,23 +389,37 @@ class GithHelper:
             branch_name (str): The branch to checkout in each repo.
         """
         base = Path(path).resolve()
+        if not base.exists():
+            GithMessage(
+                f"Directory not found: {path}",
+                GithMessageLevel.ERROR,
+            )
+        if not base.is_dir():
+            GithMessage(
+                f"Not a directory: {path}",
+                GithMessageLevel.ERROR,
+            )
         subdirs = sorted(p for p in base.iterdir() if (p / ".git").is_dir())
 
         if not subdirs:
-            GithMessage(f"No git repo found in {base}", GithMessageLevel.ERROR)
+            GithMessage(
+                f"No git repo found in {path} (resolved to {base})",
+                GithMessageLevel.ERROR,
+            )
 
         switched, skipped = 0, 0
 
         for repo_path in subdirs:
             name = repo_path.name
+            repo_str = str(repo_path)
 
             # git -C <path> runs git like we are in the repo directory
             result = subprocess.run(
-                ["git", "-C", repo_path, "branch", "--list", branch_name],
+                ["git", "-C", repo_str, "rev-parse", "--verify", f"refs/heads/{branch_name}"],
                 capture_output=True,
                 text=True,
             )
-            branch_exists_locally = branch_name in result.stdout
+            branch_exists_locally = result.returncode == 0
 
             # FIXME : case of branch not found locally but exist in remote
             # issue at https://github.com/rejamen/gith/issues/12
@@ -418,7 +432,7 @@ class GithHelper:
                 continue
 
             result = subprocess.run(
-                ["git", "-C", repo_path, "checkout", branch_name],
+                ["git", "-C", repo_str, "checkout", branch_name],
                 capture_output=True,
                 text=True,
             )
@@ -439,6 +453,5 @@ class GithHelper:
             f"Done. [green]{switched} switched[/green], [red]{skipped} skipped[/red].",
             GithMessageLevel.LOG,
         )
-
 
 gith = GithHelper()


### PR DESCRIPTION
Reported in issue #9, this commit allow to checkout all git repo inside a directory to the same branch.

It extends the checkout command to add `git -C <path>` command

## Usage : 

`gith checkout --dir=/path/to/dir --b branch_name`

## Examples tested

### Checkout to non existing branch

<img width="548" height="160" alt="image" src="https://github.com/user-attachments/assets/4bfb4bf6-5ada-413c-a146-f702eced31f3" />

### Checkout to existing branch

<img width="540" height="83" alt="image" src="https://github.com/user-attachments/assets/bd6dcf21-4c71-430c-b332-d372ae9b4b71" />

### Repo don't contain same branches' names

<img width="548" height="118" alt="image" src="https://github.com/user-attachments/assets/c124fb5f-5bb4-4759-a314-220be5f44ad1" />

### --b flag not specified

<img width="454" height="101" alt="image" src="https://github.com/user-attachments/assets/358dd9ec-1cb8-4af4-a727-7d9ede8c3ee6" />

### Normal checkout from previous implementation

<img width="374" height="60" alt="image" src="https://github.com/user-attachments/assets/b3c703fd-e174-446d-a1d3-b10ec02065f9" />

### Checkout without any option

<img width="441" height="101" alt="image" src="https://github.com/user-attachments/assets/6454132b-77cd-4708-b697-ae91112ad89c" />


